### PR TITLE
Add api endpoint that returns zenloop settings to the post purchase u…

### DIFF
--- a/app/routes/api.zenloop-settings.jsx
+++ b/app/routes/api.zenloop-settings.jsx
@@ -3,6 +3,7 @@ import { prisma } from "../db.server";
 
 export const loader = async ({ request }) => {
   await authenticate.public.checkout(request);
+  return new Response(null, { status: 204 });
 };
 
 export const action = async ({ request }) => {
@@ -80,6 +81,12 @@ async function fetchMetafields(shopDomain, accessToken) {
       },
     })
   });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("Shopify API error:", response.status, errorText);
+    return { errors: [{ message: `HTTP error ${response.status}` }] };
+  }
 
   return response.json();
 }

--- a/app/routes/api.zenloop-settings.jsx
+++ b/app/routes/api.zenloop-settings.jsx
@@ -1,0 +1,85 @@
+import { authenticate, apiVersion } from "../shopify.server";
+import { prisma } from "../db.server";
+
+export const loader = async ({ request }) => {
+  await authenticate.public.checkout(request);
+};
+
+export const action = async ({ request }) => {
+  const { cors, sessionToken } = await authenticate.public.checkout(request);
+  const shopDomain = sessionToken?.input_data?.shop?.domain;
+
+  if (!shopDomain) {
+    return cors(Response.json({ error: "Shop domain not found" }, { status: 400 }));
+  }
+
+  try {
+    const session = await prisma.session.findFirst({
+      where: { shop: shopDomain }
+    });
+
+    if (!session || !session.accessToken) {
+      console.error("Shop session not found for domain:", shopDomain);
+      return cors(Response.json({ error: "Shop session not found" }, { status: 404 }));
+    }
+    const data = await fetchMetafields(shopDomain, session.accessToken);
+
+    if (data.errors) {
+      console.error("GraphQL errors:", data.errors);
+      return cors(Response.json({ error: "Failed to fetch settings" }, { status: 500 }));
+    }
+
+    const settings = data.data?.shop?.metafield;
+
+    if (!settings) {
+      console.error("Settings metafield not found", data);
+      return cors(Response.json({ error: "Settings not found" }, { status: 404 }));
+    }
+
+    try {
+      const parsedSettings = settings.value ? JSON.parse(settings.value) : null;
+
+      if (!('orgId' in parsedSettings) || !('surveyId' in parsedSettings)) {
+        console.error("Settings JSON missing required fields:", parsedSettings);
+        return cors(Response.json({ error: "Invalid settings format" }, { status: 400 }));
+      }
+
+      return cors(Response.json({ data: parsedSettings }));
+    } catch (parseError) {
+      console.error("Error parsing settings JSON:", parseError);
+      return cors(Response.json({ error: "Failed to fetch settings" }, { status: 500 }));
+    }
+  } catch (error) {
+    console.error("Error fetching Zenloop settings:", error);
+    return cors(Response.json({ error: "Failed to fetch settings" }, { status: 500 }));
+  }
+};
+
+async function fetchMetafields(shopDomain, accessToken) {
+  const response = await fetch(`https://${shopDomain}/admin/api/${apiVersion}/graphql.json`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Shopify-Access-Token': accessToken
+    },
+    body: JSON.stringify({
+      query: `
+        query getZenloopSettings($namespace: String!, $key: String!) {
+          shop {
+            metafield(namespace: $namespace, key: $key) {
+              id
+              value
+              type
+            }
+          }
+        }
+      `,
+      variables: {
+        namespace: "zenloop",
+        key: "settings",
+      },
+    })
+  });
+
+  return response.json();
+}

--- a/extensions/zenloop-post-purchase-survey/shopify.extension.toml
+++ b/extensions/zenloop-post-purchase-survey/shopify.extension.toml
@@ -1,8 +1,6 @@
+api_version = "2025-07"
 type = "checkout_post_purchase"
 name = "zenloop-post-purchase-survey"
-
-[extension_points]
-post_purchase = "index.jsx"
 
 [capabilities]
 network_access = true
@@ -11,4 +9,3 @@ block_progress = true
 [[metafields]]
 namespace = "zenloop"
 key = "settings"
-type = "json"

--- a/extensions/zenloop-post-purchase-survey/src/index.jsx
+++ b/extensions/zenloop-post-purchase-survey/src/index.jsx
@@ -1,7 +1,8 @@
 /**
  * Extend Shopify Checkout with a custom Post Purchase user experience.
  */
-import React, { useEffect, useState } from 'react';
+
+import React from 'react';
 
 import {
   extend,
@@ -16,142 +17,46 @@ import {
   Link,
   Image,
   Separator,
-  useExtensionInput,
 } from "@shopify/post-purchase-ui-extensions-react";
 
-/**
- * Entry point for the `ShouldRender` Extension Point.
- */
-extend("Checkout::PostPurchase::ShouldRender", async ({ storage, inputData }) => {
-  const shop = inputData?.shop;
+const SURVEY_BASE_URL = "https://zenresponses.zenloop.com/";
+
+// Replace with production URL when deploying the app
+const APP_URL = "https://pas-offline-mile-juice.trycloudflare.com";
+
+extend("Checkout::PostPurchase::ShouldRender", shouldRender);
+render("Checkout::PostPurchase::Render", PostPurchaseSurvey);
+
+async function shouldRender({ storage, inputData }) {
   try {
-    const shopMetafields = shop?.metafields || [];
-    const zenloopSettings = shopMetafields.find(
-      metafield => metafield.namespace === "zenloop" && metafield.key === "settings"
-    );
+    const response = await fetchZenloopSettings(inputData?.token || "");
 
-    if (!zenloopSettings?.value) {
+    if (!response.ok) {
+      console.error(`Zenloop API error: ${response.status} ${response.statusText}`);
       return { render: false };
     }
 
-    let settings = {};
-    try {
-      settings = JSON.parse(zenloopSettings.value);
-    } catch (parseError) {
-      console.error("Failed to parse settings:", parseError);
-      return { render: false };
-    }
+    const { data } = await response.json();
+    const orgId = data?.orgId;
+    const surveyId = data?.surveyId;
 
-    const { orgId, surveyId } = settings;
     if (!orgId || !surveyId) {
-      console.error("Missing required settings");
+      console.error("Invalid Zenloop settings:", data);
       return { render: false };
     }
 
-    await storage.update({
-      orgId,
-      surveyId,
-      shop: shop?.domain
-    });
-
+    await storage.update({ orgId, surveyId });
     return { render: true };
   } catch (error) {
-    console.error("Error in ShouldRender:", error);
+    console.error("Unexpected error in shouldRender:", error);
     return { render: false };
   }
-});
+}
 
 // Post-purchase survey component
-function PostPurchaseSurvey() {
-  const { storage, inputData, done } = useExtensionInput();
-  const [shouldRender, setShouldRender] = useState(false);
-  const [settings, setSettings] = useState(null);
-  const [error, setError] = useState(null);
-  const shop = inputData?.shop;
-  const initialPurchase = inputData?.initialPurchase;
-
-  useEffect(() => {
-    async function checkSettings() {
-      try {
-        const shopMetafields = shop?.metafields || [];
-        const zenloopSettings = shopMetafields.find(
-          metafield => metafield.namespace === "zenloop" && metafield.key === "settings"
-        );
-
-        if (!zenloopSettings?.value) {
-          done();
-          return;
-        }
-
-        try {
-          const parsedSettings = JSON.parse(zenloopSettings.value);
-          const { orgId, surveyId } = parsedSettings;
-
-          if (!orgId || !surveyId) {
-            done();
-            return;
-          }
-
-          await storage.update({
-            orgId,
-            surveyId,
-            shop: shop?.domain
-          });
-
-          setSettings({ orgId, surveyId });
-          setShouldRender(true);
-        } catch (parseError) {
-          console.error("Failed to parse settings:", parseError);
-          done();
-        }
-      } catch (error) {
-        console.error("Error checking settings:", error);
-        setError("Unable to load survey. Please continue to order status.");
-        setShouldRender(true);
-      }
-    }
-
-    checkSettings();
-  }, [shop, storage, done]);
-
-  if (!shouldRender) {
-    return null;
-  }
-
-  if (error || !settings) {
-    return (
-      <View padding="base">
-        <Layout maxInlineSize={0.95}>
-          <BlockStack spacing="tight" alignment="center">
-            <TextContainer alignment="center">
-              <TextBlock appearance="critical">{error}</TextBlock>
-            </TextContainer>
-            <Button
-              kind="secondary"
-              onPress={() => done()}
-              inlineSize="fill"
-            >
-              Continue to Order Status
-            </Button>
-          </BlockStack>
-        </Layout>
-      </View>
-    );
-  }
-  
-  const baseUrl = "https://zenresponses.zenloop.com/";
-  const params = new URLSearchParams({
-    orgId: settings.orgId,
-    surveyId: settings.surveyId,
-    shop_domain: shop?.domain || "",
-    order_id: initialPurchase?.referenceId || "",
-    customer_id: initialPurchase?.customerId?.toString() || "",
-    product_title: initialPurchase?.lineItems?.[0]?.product?.title || "",
-    product_variant: initialPurchase?.lineItems?.[0]?.product?.variant?.title || "",
-    total_price: initialPurchase?.totalPriceSet?.shopMoney?.amount || "",
-    currency: initialPurchase?.totalPriceSet?.shopMoney?.currencyCode || "",
-  });
-  const surveyUrl = `${baseUrl}?${params.toString()}`;
+export function PostPurchaseSurvey({ storage, inputData, done }) {
+  const { orgId = "", surveyId = "" } = storage.initialData || {};
+  const surveyUrl = buildSurveyUrl(orgId, surveyId, inputData);
 
   return (
     <View padding="none">
@@ -160,8 +65,8 @@ function PostPurchaseSurvey() {
           <BlockStack spacing="loose">
             {/* Header Section */}
             <BlockStack alignment="center">
-            <Separator />
-              <Image 
+              <Separator />
+              <Image
                 source="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODAiIGhlaWdodD0iODAiIHZpZXdCb3g9IjAgMCA4MCA4MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iNDAiIGN5PSI0MCIgcj0iMzgiIGZpbGw9IiNGNUY1RjUiIHN0cm9rZT0iIzAwODQ2MCIgc3Ryb2tlLXdpZHRoPSI0Ii8+CjxwYXRoIGQ9Ik0yNCA0MkwzNCA1Mkw1NiAzMCIgc3Ryb2tlPSIjMDA4NDYwIiBzdHJva2Utd2lkdGg9IjYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8L3N2Zz4K"
                 fit="contain"
                 size="medium"
@@ -178,38 +83,46 @@ function PostPurchaseSurvey() {
             <Separator />
 
             {/* Survey Section */}
-            <View
-              border="base"
-              padding="loose"
-              cornerRadius="base"
-              background="subdued"
-            >
-              <BlockStack spacing="loose" alignment="center">
-                <TextContainer alignment="center">
-                  <Heading level={2}>Your Opinion Matters</Heading>
-                  <TextBlock size="medium">
-                    How was your shopping experience with us?
-                  </TextBlock>
-                </TextContainer>
-
-                <BlockStack spacing="tight" alignment="center">
-                  <Link to={surveyUrl} external>
-                    <Button
-                      kind="primary"
-                      inlineSize="fill"
-                    >
-                      Share Your Feedback
-                    </Button>
-                  </Link>
-
+            {surveyUrl ? (
+              <View
+                border="base"
+                padding="loose"
+                cornerRadius="base"
+                background="subdued"
+              >
+                <BlockStack spacing="loose" alignment="center">
                   <TextContainer alignment="center">
-                    <TextBlock size="small" emphasized appearance="subdued">
-                      Takes less than 2 minutes • Your feedback is anonymous
+                    <Heading level={2}>Your Opinion Matters</Heading>
+                    <TextBlock size="medium">
+                      How was your shopping experience with us?
                     </TextBlock>
                   </TextContainer>
+
+                  <BlockStack spacing="tight" alignment="center">
+                    <Link to={surveyUrl} external>
+                      <Button
+                        kind="primary"
+                        inlineSize="fill"
+                      >
+                        Share Your Feedback
+                      </Button>
+                    </Link>
+
+                    <TextContainer alignment="center">
+                      <TextBlock size="small" emphasized appearance="subdued">
+                        Takes less than 2 minutes • Your feedback is anonymous
+                      </TextBlock>
+                    </TextContainer>
+                  </BlockStack>
                 </BlockStack>
-              </BlockStack>
-            </View>
+              </View>
+            ) : (
+              <TextContainer alignment="center">
+                <TextBlock appearance="critical">
+                  Unable to load survey at the moment. Please try again later.
+                </TextBlock>
+              </TextContainer>
+            )}
 
             <Separator />
 
@@ -235,5 +148,34 @@ function PostPurchaseSurvey() {
   );
 }
 
-// Render the post-purchase extension
-render("Checkout::PostPurchase::Render", () => <PostPurchaseSurvey />);
+function buildSurveyUrl(orgId, surveyId, inputData) {
+  if (!orgId || !surveyId) return null;
+
+  const shop = inputData?.shop || {};
+  const initialPurchase = inputData?.initialPurchase || {};
+  const firstItem = initialPurchase?.lineItems?.[0] || {};
+
+  const params = new URLSearchParams({
+    orgId,
+    surveyId,
+    shop_domain: shop.domain || "",
+    order_id: initialPurchase.referenceId || "",
+    customer_id: initialPurchase.customerId?.toString() || "",
+    product_title: firstItem.product?.title || "",
+    product_variant: firstItem.product?.variant?.title || "",
+    total_price: initialPurchase.totalPriceSet?.shopMoney?.amount || "",
+    currency: initialPurchase.totalPriceSet?.shopMoney?.currencyCode || "",
+  });
+
+  return `${SURVEY_BASE_URL}?${params.toString()}`;
+}
+
+async function fetchZenloopSettings(token) {
+  return fetch(`${APP_URL}/api/zenloop-settings`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+}

--- a/extensions/zenloop-post-purchase-survey/src/index.jsx
+++ b/extensions/zenloop-post-purchase-survey/src/index.jsx
@@ -21,8 +21,8 @@ import {
 
 const SURVEY_BASE_URL = "https://zenresponses.zenloop.com/";
 
-// Replace with production URL when deploying the app
-const APP_URL = "https://pas-offline-mile-juice.trycloudflare.com";
+// Must be production URL when deploying the app
+const APP_URL = "https://zenloop-survey-plugin-xn48.onrender.com";
 
 extend("Checkout::PostPurchase::ShouldRender", shouldRender);
 render("Checkout::PostPurchase::Render", PostPurchaseSurvey);


### PR DESCRIPTION
Requirements: Shopify CLI (`npm install -g @shopify/latest`)

Run the Shopify app in dev

```bash
npm run dev
```

Visit the preview url to see the dev console. You will see your extension listed. Click on the extension to test it out.

<img width="978" height="477" alt="Screenshot From 2025-08-29 13-55-22" src="https://github.com/user-attachments/assets/aec6427b-d192-488a-94d0-b83a6bcadf58" />

You will be taken to a checkout screen, here you can test the `shouldRender` function. You will be able to see anything logged to the browser within this function on the checkout screen using Chrome dev tools.

After submitting checkout, if `shouldRender` returns `{ render: true }`, you will be taken to the post purchase screen. Here, you will be able to see anything logged to the browser within the `PostPurchaseSurvey` function.

> [!NOTE]  
> Since the app in production does not have the endpoint to serve the zenloop settings yet, you must change `APP_URL` in `extensions/zenloop-post-purchase-survey/src/index.jsx` to the tunnel url created after you ran `npm run dev`. However, this should only be done for testing. Once this PR is merged and the app backend has the functionality it production, then you won't need to change the `APP_URL` to test




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New secure API endpoint to retrieve Zenloop settings for the app.
  - Survey availability now determined via that API; survey URL is dynamically built with order and customer context.
  - Clear fallback message when the survey cannot be displayed.

- Refactor
  - Post-purchase survey flow simplified to reduce client-side state; rendering now uses server-provided settings and storage.

- Chores
  - Extension manifest updated to API version 2025-07 and cleaned up extension/metafield declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->