### PR TITLE
Fix post purchase extension not rendering

### DIFF
--- a/extensions/zenloop-post-purchase-survey/shopify.extension.toml
+++ b/extensions/zenloop-post-purchase-survey/shopify.extension.toml
@@ -1,8 +1,6 @@
+api_version = "2025-07"
 type = "checkout_post_purchase"
 name = "zenloop-post-purchase-survey"
-
-[extension_points]
-post_purchase = "index.jsx"
 
 [capabilities]
 network_access = true
@@ -11,4 +9,3 @@ block_progress = true
 [[metafields]]
 namespace = "zenloop"
 key = "settings"
-type = "json"


### PR DESCRIPTION
Requirements: 
- PR #1 is merged and deployed to production
- Shopify CLI (`npm install -g @shopify/latest`)

Run the Shopify app in dev

```bash
npm run dev
```

Visit the preview url to see the dev console. You will see your extension listed. Click on the extension to test it out.

<img width="978" height="477" alt="Screenshot From 2025-08-29 13-55-22" src="https://github.com/user-attachments/assets/aec6427b-d192-488a-94d0-b83a6bcadf58" />

You will be taken to a checkout screen, here you can test the `shouldRender` function. You will be able to see anything logged to the browser within this function on the checkout screen using Chrome dev tools.

After submitting checkout, if `shouldRender` returns `{ render: true }`, you will be taken to the post purchase screen. Here, you will be able to see anything logged to the browser within the `PostPurchaseSurvey` function.